### PR TITLE
Fix slack icon name is influenced by locale setting

### DIFF
--- a/pokeslack.py
+++ b/pokeslack.py
@@ -657,6 +657,8 @@ def main():
     print('[+] Locale is ' + args.locale)
     pokemonsJSON = json.load(
         codecs.open(path + '/locales/pokemon.' + args.locale + '.json', "r", 'UTF-8'))
+    pokemonsJSON_en = json.load(
+        codecs.open(path + '/locales/pokemon.en.json', "r", 'UTF-8'))
 
     if args.debug:
         global DEBUG
@@ -720,7 +722,7 @@ def main():
         (x, y) = (x + dx, y + dy)
 
         process_step(args, api_endpoint, access_token, profile_response,
-                     pokemonsJSON, ignore, only)
+                     pokemonsJSON, pokemonsJSON_en, ignore, only)
 
         print('Completed: ' + str(
             ((step+1) + pos * .25 - .25) / (steplimit2) * 100) + '%')
@@ -739,7 +741,7 @@ def main():
 
 
 def process_step(args, api_endpoint, access_token, profile_response,
-                 pokemonsJSON, ignore, only):
+                 pokemonsJSON, pokemonsJSON_en, ignore, only):
     print('[+] Searching for Pokemon at location {} {}'.format(FLOAT_LAT, FLOAT_LONG))
     origin = LatLng.from_degrees(FLOAT_LAT, FLOAT_LONG)
     step_lat = FLOAT_LAT
@@ -794,6 +796,7 @@ transform_from_wgs_to_gcj(Location(Fort.Latitude, Fort.Longitude))
     for poke in visible:
         pokeid = str(poke.pokemon.PokemonId)
         pokename = pokemonsJSON[pokeid]
+        pokename_en = pokemonsJSON_en[pokeid]
         if args.ignore:
             if pokename.lower() in ignore or pokeid in ignore:
                 continue
@@ -838,7 +841,7 @@ transform_from_wgs_to_gcj(Location(Fort.Latitude, Fort.Longitude))
                          ' (' + disappear_minutes + ':' + disappear_seconds + ')!'
 
             if pokemon_icons_prefix != ':pokeball:':
-                user_icon = pokemon_icons_prefix + pokename.lower() + ':'
+                user_icon = pokemon_icons_prefix + pokename_en.lower() + ':'
             else:
                 user_icon = ':pokeball:'
 


### PR DESCRIPTION
I use this slack bot with Japanese translation and [Slack Emoji Pokémon](https://github.com/Templarian/slack-emoji-pokemon).
However, icon text also translated and can't show correctly.

I fixed this problem by following solution.
1. Load English resource always.
2. Use values from English resource in `user_icon`

Before
![before](https://cloud.githubusercontent.com/assets/13718835/17085504/1c22edc0-5215-11e6-94ce-8b677d771f51.PNG)

After
![after](https://cloud.githubusercontent.com/assets/13718835/17085505/2199b3d8-5215-11e6-93f1-fdf98220d0a7.PNG)
